### PR TITLE
Allow = in values.

### DIFF
--- a/cl-ini.lisp
+++ b/cl-ini.lisp
@@ -31,9 +31,9 @@
              (mapcar #'str:trim (str:lines (str:from-file file)))))
 
 (defun parse-keypair (keypair)
-  (let* ((split (mapcar #'str:trim (str:split "=" keypair)))
-         (key (to-keyword (first split)))
-         (value (parse-value (cadr split))))
+  (let* ((split (str:split "=" keypair))
+         (key (to-keyword (str:trim (first split))))
+         (value (parse-value (str:trim (str:join "=" (cdr split))))))
     (cons key value)))
 
 (defun parse-value (value)

--- a/t/main.lisp
+++ b/t/main.lisp
@@ -1,6 +1,6 @@
 (in-package :cl-ini-test)
 
-(plan 4)
+(plan 5)
 
 (defvar *ini*
   (parse-ini (merge-pathnames "t/test.ini"
@@ -10,5 +10,6 @@
 (isnt (ini-value *ini* :var1 :section :test) 1)
 (is (ini-value *ini* :var1 :section :test) 3)
 (is (ini-value *ini* :string-test :section :test2) "four")
+(is (ini-value *ini* :equals-test :section :test3) "th=r==ee=")
 
 (finalize)

--- a/t/test.ini
+++ b/t/test.ini
@@ -9,3 +9,7 @@ var3 = 4
 ;; this should get stripped
 [Test2]
 string-test = four
+
+;; = in values should be kept
+[Test3]
+equals-test = th=r==ee=


### PR DESCRIPTION
If a value has an = sign, it should stay there. Currently the code truncates the value at the = if there is one. 